### PR TITLE
feat: include chainlink pallet send request example

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the [Chainlink](https://chain.link/) feed pallet as well as an example node showing how to integrate
 it in [Substrate](https://www.substrate.io/)-based chains.
 
-It also includes the (outdated) `pallet-chainlink` for interacting with the Chainlink job-based oracle system.
+It also includes the `pallet-chainlink` for interacting with the Chainlink job-based oracle system.
 
 ## How to integrate the Chainlink feed pallet into a runtime?
 The pallet is added to the runtime like any regular pallet (see [tutorial](https://substrate.dev/docs/en/tutorials/add-a-pallet/)).

--- a/pallet-chainlink-feed/README.md
+++ b/pallet-chainlink-feed/README.md
@@ -1,11 +1,11 @@
-# Chainlink Price Feed Module
+# Chainlink Price Feed Pallet
 
 This pallet provides Chainlink price feed functionality to Substrate-based chains that include it.
 
 It aims to mostly port the [FluxAggregator](https://github.com/smartcontractkit/chainlink/blob/dabada25f5dd7bbc49a76ed1d172a83083cdd8f0/evm-contracts/src/v0.6/FluxAggregator.sol)
 Solidity contract but changes the design in the following ways:
-+ **Storage Pruning:** It is usually not advisable to keep all oracle state around, so we add storage pruning logic
-  to the pallet. (See the `prune` extrinsic.)
++ **Storage Pruning:** It is usually not advisable to keep all oracle state around, so a feed supports 
+  automatic storage pruning.
 + **View Functions:** Substrate does not have an exact equivalent of Solidity view functions. We will instead make the
   client side smarter to read and interpret storage to surface the same information.
 + **Contracts --> Feeds:** Vanilla Substrate does not have contracts. We will thus replace the deployment of a contract with
@@ -27,7 +27,7 @@ The following snippet shows an example:
 ```Rust
 parameter_types! {
     // Used to generate the fund account that pools oracle payments.
-	pub const FeedModule: ModuleId = ModuleId(*b"linkfeed");
+	pub const FeedModule: PalletId = PalletId(*b"linkfeed");
     // The minimum amount of tokens to keep in reserve for oracle payment.
 	pub const MinimumReserve: Balance = ExistentialDeposit::get() * 1000;
     // Maximum length of the feed description.
@@ -36,26 +36,26 @@ parameter_types! {
 	pub const OracleCountLimit: u32 = 25;
     // Maximum number of feeds.
 	pub const FeedLimit: FeedId = 100;
-    // Minimum amount of rounds to keep when pruning.
-	pub const PruningWindow: RoundId = 15;
 }
 
-impl pallet_chainlink_feed::Trait for Runtime {
-	type Event = Event;
-	type FeedId = FeedId;
-	type Value = Value;
+impl pallet_chainlink_feed::Config for Runtime {
+    type Event = Event;
+    type FeedId = FeedId;
+    type Value = Value;
     // A module that provides currency functionality to manage
     // oracle rewards. Balances in this example.
-	type Currency = Balances;
-	type ModuleId = FeedModule;
-	type MinimumReserve = MinimumReserve;
-	type StringLimit = StringLimit;
-	type OracleCountLimit = OracleCountLimit;
-	type FeedLimit = FeedLimit;
-	type PruningWindow = PruningWindow;
+    type Currency = Balances;
+    type PalletId = FeedPalletId;
+    type MinimumReserve = MinimumReserve;
+    type StringLimit = StringLimit;
+    type OracleCountLimit = OracleCountLimit;
+    type FeedLimit = FeedLimit;
+    // Provide your custom callback that gets called once a new value is available
+    // `()` is a noop
+    type OnAnswerHandler = ();
     // Implementation of the WeightInfo trait for your runtime.
     // Default weights available in the pallet but not recommended for production.
-	type WeightInfo = ChainlinkWeightInfo;
+    type WeightInfo = ChainlinkWeightInfo;
 }
 ```
 
@@ -65,7 +65,7 @@ depends on a pallet implementing the `Currency` trait.
 Define an associated `Oracle` type implementing the `FeedOracle` trait.
 
 ```Rust
-pub trait Trait: frame_system::Trait {
+pub trait Config: frame_system::Config {
     // -- snip --
     type Oracle: FeedOracle<Self>;
 }
@@ -101,7 +101,6 @@ Pallet-global values:
 ```
 PalletAdmin
 PendingPalletAdmin
-Debt
 FeedCounter
 ```
 

--- a/pallet-chainlink/README.md
+++ b/pallet-chainlink/README.md
@@ -1,12 +1,11 @@
 # Chainlink pallet
 
-> NOTE: Still on Substrate pre-v2 and not compatible with the example node in this repo.
-
 ## Purpose
 
 This pallet allows your substrate built parachain/blockchain to interract with [chainlink](https://chain.link/). [Pallets](https://substrate.dev/docs/en/tutorials/build-a-dapp/pallet) are modular pieces of the Polkadot Substrate that make it easier for your parachain to interact with technologies. This is essential for working with any kind of external data API from outside your blockchain.
 
 Essentially, a pallet is a lego piece you can add to another blockchain built on the Substrate/Polkadot infrastructure.
+
 
 ## Installation
 
@@ -43,8 +42,8 @@ Edit `lib.rs` to that it references `pallet-chainlink`:
 
 ```rust
 ...
-// Add the chainlink Trait
-impl chainlink::Trait for Runtime {
+// Add the chainlink Config Trait
+impl chainlink::Config for Runtime {
   type Event = Event;
   type Currency = balances::Module<Runtime>;
   type Callback = example_module::Call<Runtime>;
@@ -59,7 +58,7 @@ parameter_types! {
 ...
 construct_runtime!(
     ...
-    Chainlink: chainlink::{Module, Call, Storage, Event<T>},
+    Chainlink: chainlink::{Pallet, Call, Storage, Event<T>},
   }
 );
 ```
@@ -67,11 +66,11 @@ construct_runtime!(
 Add necessary `use` declarations:
 
 ```rust
-use chainlink::{CallbackWithParameter, Event, Trait as ChainlinkTrait};
+use chainlink::{CallbackWithParameter, Event, Config as ChainlinkConfig};
 
-pub trait Trait: chainlink::Trait + ChainlinkTrait {
-    type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
-    type Callback: From<Call<Self>> + Into<<Self as ChainlinkTrait>::Callback>;
+pub trait Config: chainlink::Config + ChainlinkTrait {
+    type Event: From<Event<Self>> + Into<<Self as system::Config>::Event>;
+    type Callback: From<Call<Self>> + Into<<Self as ChainlinkConfig>::Callback>;
 }
 ```
 
@@ -80,8 +79,8 @@ You can now call the right chainlink Extrinsic:
 ```rust
 pub fn send_request(origin, operator: T::AccountId) -> DispatchResult {
     let parameters = ("get", "https://min-api.cryptocompare.com/data/pricemultifull?fsyms=ETH&tsyms=USD", "path", "RAW.ETH.USD.PRICE", "times", "100000000");
-    let call: <T as Trait>::Callback = Call::callback(vec![]).into();
-    <chainlink::Module<T>>::initiate_request(origin, operator, 1, 0, parameters.encode(), 100, call.into())?;
+    let call: <T as Config>::Callback = Call::callback(vec![]).into();
+    chainlink::Pallet::<T>::initiate_request(origin, operator, 1, 0, parameters.encode(), 100, call.into())?;
 
     Ok(())
 }
@@ -98,7 +97,7 @@ pub fn callback(origin, result: u128) -> DispatchResult {
     Ok(())
 }
 
-impl <T: Trait> CallbackWithParameter for Call<T> {
+impl <T: Config> CallbackWithParameter for Call<T> {
     fn with_result(&self, result: u128) -> Option<Self> {
         match *self {
             Call::callback(_) => Some(Call::callback(result)),

--- a/substrate-node-example/runtime/src/example.rs
+++ b/substrate-node-example/runtime/src/example.rs
@@ -1,0 +1,65 @@
+use codec::{Decode, Encode};
+use frame_support::sp_runtime::traits::UniqueSaturatedFrom;
+use frame_support::traits::Currency;
+use frame_support::{decl_module, decl_storage, dispatch::DispatchResult};
+use frame_system::ensure_root;
+use pallet_chainlink::{CallbackWithParameter, Config as ChainlinkTrait, Event};
+use sp_std::prelude::*;
+
+type BalanceOf<T> = <<T as pallet_chainlink::Config>::Currency as Currency<
+	<T as frame_system::Config>::AccountId,
+>>::Balance;
+
+pub trait Config: pallet_chainlink::Config + ChainlinkTrait {
+	type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
+	type Callback: From<Call<Self>> + Into<<Self as ChainlinkTrait>::Callback>;
+}
+
+decl_storage! {
+	trait Store for Module<T: Config> as ExampleStorage {
+		pub Result: i128;
+	}
+}
+
+decl_module! {
+	pub struct Module<T: Config> for enum Call where origin: T::Origin {
+		fn deposit_event() = default;
+
+		#[weight = 0]
+		pub fn send_request(origin, operator: T::AccountId, specid: Vec<u8>) -> DispatchResult {
+			let parameters = ("get", "https://min-api.cryptocompare.com/data/pricemultifull?fsyms=ETH&tsyms=USD", "path", "RAW.ETH.USD.PRICE", "times", "100000000");
+			let call: <T as Config>::Callback = Call::callback(vec![]).into();
+
+			let fee = BalanceOf::<T>::unique_saturated_from(100u32);
+			<pallet_chainlink::Pallet<T>>::initiate_request(origin, operator, specid, 0, parameters.encode(), fee, call.into())?;
+
+			Ok(())
+		}
+
+		#[weight = 0]
+		pub fn callback(origin, result: Vec<u8>) -> DispatchResult {
+			ensure_root(origin)?;
+
+			// The result is expected to be a SCALE encoded `i128`
+			let r : i128 = i128::decode(&mut &result[..]).map_err(|_| Error::<T>::DecodingFailed)?;
+			<Result>::put(r);
+
+			Ok(())
+		}
+	}
+}
+
+frame_support::decl_error! {
+	pub enum Error for Module<T: Config> {
+		DecodingFailed
+	}
+}
+
+impl<T: Config> CallbackWithParameter for Call<T> {
+	fn with_result(&self, result: Vec<u8>) -> Option<Self> {
+		match *self {
+			Call::callback(_) => Some(Call::callback(result)),
+			_ => None,
+		}
+	}
+}

--- a/substrate-node-example/runtime/src/lib.rs
+++ b/substrate-node-example/runtime/src/lib.rs
@@ -36,6 +36,7 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
+pub use example::Call as ExampleCall;
 pub use pallet_chainlink_feed;
 pub use pallet_chainlink_feed::RoundId;
 /// Import the template pallet.
@@ -45,6 +46,8 @@ use weights::pallet_chainlink_feed::WeightInfo as ChainlinkWeightInfo;
 // Make the WASM binary available.
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+
+mod example;
 
 pub mod weights;
 
@@ -281,6 +284,11 @@ impl pallet_sudo::Config for Runtime {
 	type Call = Call;
 }
 
+impl example::Config for Runtime {
+	type Event = Event;
+	type Callback = ExampleCall<Runtime>;
+}
+
 pub type FeedId = u32;
 pub type Value = u128;
 
@@ -318,12 +326,10 @@ parameter_types! {
 
 impl pallet_chainlink::Config for Runtime {
 	type Event = Event;
-	type Currency = pallet_balances::Pallet<Runtime>;
-	type Callback = module2::Call<Runtime>;
+	type Currency = Balances;
+	type Callback = ExampleCall<Runtime>;
 	type ValidityPeriod = ValidityPeriod;
 }
-
-impl module2::Config for Runtime {}
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
@@ -344,6 +350,7 @@ construct_runtime!(
 		ChainlinkFeed: pallet_chainlink_feed::{Pallet, Call, Config<T>, Storage, Event<T>},
 		TemplateModule: pallet_template::{Pallet, Call, Storage, Event<T>},
 
+		Example: example::{Pallet, Call, Storage},
 		Chainlink: pallet_chainlink::{Pallet, Call, Storage, Event<T>}
 	}
 );
@@ -544,48 +551,6 @@ impl_runtime_apis! {
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)
-		}
-	}
-}
-
-pub mod module2 {
-	use super::*;
-	use codec::Decode;
-	use pallet_chainlink::CallbackWithParameter;
-
-	pub trait Config: frame_system::Config {}
-
-	frame_support::decl_module! {
-		pub struct Module<T: Config> for enum Call
-			where origin: <T as frame_system::Config>::Origin
-		{
-			#[weight = 0]
-			pub fn callback(_origin, result: Vec<u8>) -> frame_support::dispatch::DispatchResult {
-				let r : u128 = u128::decode(&mut &result[..]).map_err(|_| Error::<T>::DecodingFailed)?;
-				<Result>::put(r);
-				Ok(())
-			}
-		}
-	}
-
-	frame_support::decl_storage! {
-		trait Store for Module<T: Config> as TestStorage {
-			pub Result: u128;
-		}
-	}
-
-	frame_support::decl_error! {
-		pub enum Error for Module<T: Config> {
-			DecodingFailed
-		}
-	}
-
-	impl<T: Config> CallbackWithParameter for Call<T> {
-		fn with_result(&self, result: Vec<u8>) -> Option<Self> {
-			match *self {
-				Call::callback(_) => Some(Call::callback(result)),
-				_ => None,
-			}
 		}
 	}
 }

--- a/substrate-node-example/types.json
+++ b/substrate-node-example/types.json
@@ -1,4 +1,7 @@
 {
+  "SpecIndex": "Vec<u8>",
+  "RequestIdentifier": "u64",
+  "DataVersion": "u64",
   "Address": "MultiAddress",
   "LookupSource": "MultiAddress",
   "FeedId": "u32",


### PR DESCRIPTION
# Changes
- add an `example` module for the runtime that calls into the chainlink-pallet
- fix missing `RequestIdentifier` type for front-end

This reverts commit f2a5bf49f6fe54d98599fa874d7be5b7702ff58b.