### PR TITLE
feat: support conditional payment for submission and make them operational 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 pallet-chainlink**/Cargo.lock
 **/node_modules
 **/yarn.lock
+**/*.DS_Store
 external_initiator.env

--- a/pallet-chainlink-feed/src/lib.rs
+++ b/pallet-chainlink-feed/src/lib.rs
@@ -42,11 +42,12 @@ pub mod pallet {
 		utils::{median, with_transaction_result},
 	};
 
-	/// Configuration for submiting paysfee
+	/// Explicit enum to denote if the submitter pays fee for `submit` extrinsic or not.
 	pub enum SubmitterPaysFee {
-		/// Always pays for the transaction
+		/// Submitter always pays the fee.
 		Always,
-		/// No pays for valid submission
+		/// `submit` is free for the submitter if the submission is valid,
+		/// otherwise the submitter pays the regular fee.
 		FreeForValidSubmission,
 	}
 
@@ -329,7 +330,7 @@ pub mod pallet {
 		/// The weight for this pallet's extrinsics.
 		type WeightInfo: WeightInfo;
 
-		/// If enable PaysFee in submit call
+		/// Denote if the submitter pays a fee for valid submission in `submit` or not.
 		type SubmitterPaysFee: Get<SubmitterPaysFee>;
 	}
 

--- a/pallet-chainlink-feed/src/mock.rs
+++ b/pallet-chainlink-feed/src/mock.rs
@@ -87,6 +87,7 @@ parameter_types! {
 	pub const StringLimit: u32 = 15;
 	pub const OracleLimit: u32 = 10;
 	pub const FeedLimit: u16 = 10;
+	pub const PaysFeeConf: pallet_chainlink_feed::SubmitterPaysFee = pallet_chainlink_feed::SubmitterPaysFee::FreeForValidSubmission;
 }
 
 type FeedId = u16;
@@ -110,6 +111,7 @@ impl pallet_chainlink_feed::Config for Test {
 	type OracleCountLimit = OracleLimit;
 	type FeedLimit = FeedLimit;
 	type WeightInfo = ();
+	type SubmitterPaysFee = PaysFeeConf;
 }
 
 #[derive(Debug, Default)]

--- a/pallet-chainlink-feed/src/tests.rs
+++ b/pallet-chainlink-feed/src/tests.rs
@@ -224,7 +224,7 @@ fn details_are_cleared() {
 				submission
 			));
 			assert_ok!(ChainlinkFeed::submit(
-				Origin::signed(snd_oracle),
+				Origin::signed(snd_oracle.clone()),
 				feed_id,
 				r,
 				submission
@@ -293,7 +293,7 @@ fn submit_failure_cases() {
 		let invalid_round = 1337;
 		assert_noop!(
 			ChainlinkFeed::submit(Origin::signed(oracle), feed_id, invalid_round, submission),
-			Error::<Test>::InvalidRound
+			Error::<Test>::InvalidRound,
 		);
 		let low_value = 0;
 		assert_noop!(

--- a/substrate-node-example/front-end/src/config/types.json
+++ b/substrate-node-example/front-end/src/config/types.json
@@ -7,6 +7,12 @@
   "FeedId": "u32",
   "RoundId": "u32",
   "Value": "u128",
+  "SubmitterPaysFee": {
+    "_enum": [
+      "Always",
+      "FreeForValidSubmission"
+    ]
+  },
   "FeedConfig": {
     "owner": "AccountId",
     "pending_owner": "Option<AccountId>",

--- a/substrate-node-example/runtime/src/lib.rs
+++ b/substrate-node-example/runtime/src/lib.rs
@@ -298,6 +298,7 @@ parameter_types! {
 	pub const StringLimit: u32 = 30;
 	pub const OracleCountLimit: u32 = 25;
 	pub const FeedLimit: FeedId = 100;
+    pub const PaysFeeConf: pallet_chainlink_feed::SubmitterPaysFee = pallet_chainlink_feed::SubmitterPaysFee::FreeForValidSubmission;
 }
 
 impl pallet_chainlink_feed::Config for Runtime {
@@ -312,6 +313,7 @@ impl pallet_chainlink_feed::Config for Runtime {
 	type FeedLimit = FeedLimit;
 	type OnAnswerHandler = ();
 	type WeightInfo = ChainlinkWeightInfo;
+    type SubmitterPaysFee = PaysFeeConf;
 }
 
 /// Configure the template pallet in pallets/template.

--- a/substrate-node-example/types.json
+++ b/substrate-node-example/types.json
@@ -7,6 +7,12 @@
   "FeedId": "u32",
   "RoundId": "u32",
   "Value": "u128",
+  "SubmitterPaysFee": {
+    "_enum": [
+      "Always",
+      "FreeForValidSubmission"
+    ]
+  },
   "FeedConfig": {
     "owner": "AccountId",
     "pending_owner": "Option<AccountId>",


### PR DESCRIPTION
# Changes

The `submit` is marked as `operational` with [DispatchClass](https://crates.parity.io/frame_support/weights/enum.DispatchClass.html) 

Whether operators should be pay the fee for submitting values (`submit`) can now be configured with `SubmitterPaysFee`