### PR TITLE
feat: make transfers from valid admins noops

### DIFF
--- a/pallet-chainlink-feed/src/lib.rs
+++ b/pallet-chainlink-feed/src/lib.rs
@@ -657,6 +657,10 @@ pub mod pallet {
 		}
 
 		/// Initiate the transfer of the feed to `new_owner`.
+		/// Limited to the current owner of the feed.
+		///
+		/// This is a noop if the requested `new_owner` is the sender itself
+		/// and the sender is already the owner.
 		#[pallet::weight(T::WeightInfo::transfer_ownership())]
 		pub fn transfer_ownership(
 			origin: OriginFor<T>,
@@ -666,6 +670,10 @@ pub mod pallet {
 			let old_owner = ensure_signed(origin)?;
 			let mut feed = Self::feed_config(feed_id).ok_or(Error::<T>::FeedNotFound)?;
 			ensure!(feed.owner == old_owner, Error::<T>::NotFeedOwner);
+			if old_owner == new_owner {
+				// nothing to transfer
+				return Ok(().into());
+			}
 
 			feed.pending_owner = Some(new_owner.clone());
 			Feeds::<T>::insert(feed_id, feed);
@@ -1039,6 +1047,9 @@ pub mod pallet {
 
 		/// Initiate an admin transfer for the given oracle.
 		/// Limited to the oracle admin account.
+		///
+		/// This is a noop if the requested `new_admin` is the sender itself
+		/// and the sender is already the oracle admin.
 		#[pallet::weight(T::WeightInfo::transfer_admin())]
 		pub fn transfer_admin(
 			origin: OriginFor<T>,
@@ -1049,6 +1060,10 @@ pub mod pallet {
 			let mut oracle_meta = Self::oracle(&oracle).ok_or(Error::<T>::OracleNotFound)?;
 
 			ensure!(oracle_meta.admin == old_admin, Error::<T>::NotAdmin);
+			if old_admin == new_admin {
+				// nothing to transfer
+				return Ok(().into());
+			}
 
 			oracle_meta.pending_admin = Some(new_admin.clone());
 			Oracles::<T>::insert(&oracle, oracle_meta);
@@ -1135,6 +1150,9 @@ pub mod pallet {
 
 		/// Initiate an admin transfer for the pallet.
 		/// Limited to the pallet admin account.
+		///
+		/// This is a noop if the requested `new_pallet_admin` is the sender itself
+		/// and the sender is already the pallet admin.
 		#[pallet::weight(T::WeightInfo::transfer_pallet_admin())]
 		pub fn transfer_pallet_admin(
 			origin: OriginFor<T>,
@@ -1146,6 +1164,10 @@ pub mod pallet {
 				Self::pallet_admin() == old_admin,
 				Error::<T>::NotPalletAdmin
 			);
+			if old_admin == new_pallet_admin {
+				// nothing to transfer
+				return Ok(().into());
+			}
 
 			PendingPalletAdmin::<T>::put(&new_pallet_admin);
 

--- a/pallet-chainlink-feed/src/tests.rs
+++ b/pallet-chainlink-feed/src/tests.rs
@@ -622,6 +622,20 @@ fn admin_transfer_should_work() {
 			ChainlinkFeed::transfer_admin(Origin::signed(123), oracle, new_admin),
 			Error::<Test>::NotAdmin
 		);
+
+		// transfer to self yields nothing
+		assert_ok!(ChainlinkFeed::transfer_admin(
+			Origin::signed(old_admin),
+			oracle,
+			old_admin
+		));
+		assert!(System::events().into_iter().all(|r| {
+			!matches!(
+				r.event,
+				mock::Event::ChainlinkFeed(crate::Event::OracleAdminUpdateRequested(_, _, _))
+			)
+		}));
+
 		assert_ok!(ChainlinkFeed::transfer_admin(
 			Origin::signed(old_admin),
 			oracle,
@@ -822,6 +836,19 @@ fn transfer_ownership_should_work() {
 			ChainlinkFeed::transfer_ownership(Origin::signed(23), feed_id, new_owner),
 			Error::<Test>::NotFeedOwner
 		);
+		// transfer to self yields nothing
+		assert_ok!(ChainlinkFeed::transfer_ownership(
+			Origin::signed(old_owner),
+			feed_id,
+			old_owner
+		));
+		assert!(System::events().into_iter().all(|r| {
+			!matches!(
+				r.event,
+				mock::Event::ChainlinkFeed(crate::Event::OwnerUpdateRequested(_, _, _))
+			)
+		}));
+
 		assert_ok!(ChainlinkFeed::transfer_ownership(
 			Origin::signed(old_owner),
 			feed_id,
@@ -1000,6 +1027,17 @@ fn transfer_pallet_admin_should_work() {
 			ChainlinkFeed::transfer_pallet_admin(Origin::signed(123), new_admin),
 			Error::<Test>::NotPalletAdmin
 		);
+		// transfer to self yields nothing
+		assert_ok!(ChainlinkFeed::transfer_pallet_admin(
+			Origin::signed(fund),
+			fund
+		));
+		assert!(System::events().into_iter().all(|r| {
+			!matches!(
+				r.event,
+				mock::Event::ChainlinkFeed(crate::Event::PalletAdminUpdateRequested(_, _))
+			)
+		}));
 		assert_ok!(ChainlinkFeed::transfer_pallet_admin(
 			Origin::signed(fund),
 			new_admin


### PR DESCRIPTION
# Changes
Valid ownership transfers to the sender's account do nothing, therefor we can safely skip all hand over routines if the old is also the requested new owner

- Closes #85