### PR TITLE
fix: limit reduce debt to pallet admin

### DIFF
--- a/pallet-chainlink-feed/src/benchmarking.rs
+++ b/pallet-chainlink-feed/src/benchmarking.rs
@@ -594,7 +594,7 @@ benchmarks! {
 		let rounds: BalanceOf<T> = rounds.into();
 		let debt: BalanceOf<T> = rounds * payment;
 		T::Currency::make_free_balance_be(&fund_account, payment + payment);
-	}: _(RawOrigin::Signed(caller.clone()), feed, payment)
+	}: _(RawOrigin::Signed(pallet_admin.clone()), feed, payment)
 	verify {
 	}
 

--- a/pallet-chainlink-feed/src/lib.rs
+++ b/pallet-chainlink-feed/src/lib.rs
@@ -1142,7 +1142,9 @@ pub mod pallet {
 			feed_id: T::FeedId,
 			amount: BalanceOf<T>,
 		) -> DispatchResultWithPostInfo {
-			let _sender = ensure_signed(origin)?;
+			let sender = ensure_signed(origin)?;
+			ensure!(sender == Self::pallet_admin(), Error::<T>::NotPalletAdmin);
+
 			let mut feed = <Feed<T>>::load_from(feed_id).ok_or(<Error<T>>::FeedNotFound)?;
 
 			let to_reserve = amount.min(feed.config.debt);

--- a/pallet-chainlink-feed/src/tests.rs
+++ b/pallet-chainlink-feed/src/tests.rs
@@ -1210,7 +1210,11 @@ fn can_go_into_debt_and_repay() {
 		assert_eq!(Balances::free_balance(admin), new_funds - 10);
 		assert_eq!(ChainlinkFeed::debt(0).unwrap(), payment - 10);
 		// should be possible to overshoot in passing the amount correcting debt...
-		assert_ok!(ChainlinkFeed::reduce_debt(Origin::signed(42), 0, payment));
+		assert_ok!(ChainlinkFeed::reduce_debt(
+			Origin::signed(admin),
+			0,
+			payment
+		));
 		// ... but will only correct the debt
 		assert_eq!(Balances::free_balance(admin), new_funds - payment);
 		assert_eq!(ChainlinkFeed::debt(0).unwrap(), 0);
@@ -1351,7 +1355,11 @@ fn allows_submissions_until_max_debt() {
 
 		// reduce debt withdraw and submit again
 		Balances::make_free_balance_be(&admin, max_debt + ExistentialDeposit::get());
-		assert_ok!(ChainlinkFeed::reduce_debt(Origin::signed(1), 0, max_debt));
+		assert_ok!(ChainlinkFeed::reduce_debt(
+			Origin::signed(admin),
+			0,
+			max_debt
+		));
 		// now max_debt amount is reserved and can be withdrawn
 		assert_eq!(Balances::reserved_balance(&admin), max_debt);
 

--- a/pallet-chainlink-feed/src/tests.rs
+++ b/pallet-chainlink-feed/src/tests.rs
@@ -1205,6 +1205,13 @@ fn can_go_into_debt_and_repay() {
 		assert_eq!(ChainlinkFeed::debt(0).unwrap(), payment);
 		let new_funds = 2 * payment;
 		Balances::make_free_balance_be(&admin, new_funds);
+
+		// reducing debt should fail for non admin
+		assert_noop!(
+			ChainlinkFeed::reduce_debt(Origin::signed(1), 0, 10),
+			Error::<Test>::NotPalletAdmin
+		);
+
 		// should be possible to reduce debt partially
 		assert_ok!(ChainlinkFeed::reduce_debt(Origin::signed(admin), 0, 10));
 		assert_eq!(Balances::free_balance(admin), new_funds - 10);


### PR DESCRIPTION
# Changes
- ensure `reduce_debt` is called by the pallet_admin

# Issues
- Closes #96