### PR TITLE
fix: set oracle admin explicitly in feedconfig oracles

### DIFF
--- a/fm-demo/feedSetup.js
+++ b/fm-demo/feedSetup.js
@@ -40,8 +40,13 @@ async function registerFeedCreatorIfNeeded(api, aliceAccount, operatorAccount) {
 }
 async function createFeed(api, sender) {
     console.log(`Creating feed with config: ${JSON.stringify(feedConfig, null, 4)}`);
+
+    // make the pallet admin also the oracle admin
+    const palletAdmin =  await api.query.chainlinkFeed.palletAdmin();
+    feedConfig.oracles = feedConfig.oracles.map(oracle => [oracle, palletAdmin]);
+
     return new Promise(async (resolve) => {
-    await api.tx.chainlinkFeed.createFeed(feedConfig.payment, feedConfig.timeout, feedConfig.submissionValueBounds, feedConfig.minSubmissions, feedConfig.decimals, feedConfig.description, feedConfig.restartDelay, feedConfig.oracles,feedConfig.pruningWindow,feedConfig.maxDebt).signAndSend(sender, ({ status, events }) => {
+    await api.tx.chainlinkFeed.createFeed(feedConfig.payment, feedConfig.timeout, feedConfig.submissionValueBounds, feedConfig.minSubmissions, feedConfig.decimals, feedConfig.description, feedConfig.restartDelay,feedConfig.oracles,feedConfig.pruningWindow,feedConfig.maxDebt).signAndSend(sender, ({ status, events }) => {
         if (status.isInBlock || status.isFinalized) {
           events
             // find/filter for failed events

--- a/substrate-node-example/types.json
+++ b/substrate-node-example/types.json
@@ -67,5 +67,7 @@
     "answered_in_round": "RoundId"
   },
   "RoundDataOf": "RoundData",
-  "SubmissionBounds": "(u32, u32)"
+  "SubmissionBounds": "(u32, u32)",
+  "BlockNumberFor": "BlockNumber",
+  "FeedValueFor": "Value"
 }


### PR DESCRIPTION
the `createFeed` was invoked with `[Account]` instead of `[[Account]]` causing some tuple encoding issues so that, `111111111111111111111111111111111HC1` was set as the oracle's admin. This is definitely a `polkadotjs/Tuple` thing.
I fixed this by setting each of the oracle's admin to the `palletAdmin`