### PR TITLE
Bump to polkadot-v0.9.11

### DIFF
--- a/pallet-chainlink-feed/Cargo.lock
+++ b/pallet-chainlink-feed/Cargo.lock
@@ -137,10 +137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 
 [[package]]
-name = "bitflags"
-version = "1.2.1"
+name = "base64"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
@@ -217,9 +223,6 @@ name = "cc"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -456,7 +459,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -464,6 +467,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
+ "scale-info",
  "sp-api",
  "sp-io",
  "sp-runtime",
@@ -474,19 +478,20 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "14.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96616f82e069102b95a72c87de4c84d2f87ef7f0f20630e78ce3824436483110"
 dependencies = [
+ "cfg-if 1.0.0",
  "parity-scale-codec",
+ "scale-info",
  "serde",
- "sp-core",
- "sp-std",
 ]
 
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -496,6 +501,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "paste",
+ "scale-info",
  "serde",
  "smallvec",
  "sp-arithmetic",
@@ -512,7 +518,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -524,7 +530,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -536,7 +542,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -546,12 +552,12 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "frame-support",
- "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-core",
  "sp-io",
@@ -769,13 +775,13 @@ dependencies = [
 
 [[package]]
 name = "hmac-drbg"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -832,15 +838,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
-name = "jobserver"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,18 +863,50 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
+checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
 dependencies = [
  "arrayref",
- "crunchy",
- "digest 0.8.1",
+ "base64",
+ "digest 0.9.0",
  "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
  "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.4.1",
+ "serde",
+ "sha2 0.9.5",
  "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle 2.4.1",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -1121,13 +1150,14 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
  "parity-scale-codec",
+ "scale-info",
  "sp-runtime",
  "sp-std",
 ]
@@ -1141,6 +1171,7 @@ dependencies = [
  "frame-system",
  "pallet-balances",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-arithmetic",
  "sp-core",
@@ -1151,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec 0.7.1",
  "bitvec",
@@ -1165,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1317,6 +1348,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-serde",
+ "scale-info",
  "uint",
 ]
 
@@ -1344,9 +1376,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
 dependencies = [
  "unicode-xid",
 ]
@@ -1562,20 +1594,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruzstd"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cada0ef59efa6a5f4dc5e491f93d9f31e3fc7758df421ff1de8a706338e1100"
-dependencies = [
- "byteorder",
- "twox-hash",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "scale-info"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55b744399c25532d63a0d2789b109df8d46fc93752d46b0782991a931a782f"
+dependencies = [
+ "bitvec",
+ "cfg-if 1.0.0",
+ "derive_more",
+ "parity-scale-codec",
+ "scale-info-derive",
+ "serde",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "schnorrkel"
@@ -1650,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -1728,14 +1776,14 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "hash-db",
  "log",
@@ -1752,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -1764,9 +1812,10 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-core",
  "sp-io",
@@ -1776,11 +1825,12 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "integer-sqrt",
  "num-traits",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -1790,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -1813,6 +1863,7 @@ dependencies = [
  "primitive-types",
  "rand 0.7.3",
  "regex",
+ "scale-info",
  "schnorrkel",
  "secrecy",
  "serde",
@@ -1834,7 +1885,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1844,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -1855,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -1869,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "futures",
  "hash-db",
@@ -1880,7 +1931,6 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-keystore",
- "sp-maybe-compressed-blob",
  "sp-runtime-interface",
  "sp-state-machine",
  "sp-std",
@@ -1894,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -1908,18 +1958,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-maybe-compressed-blob"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
-dependencies = [
- "ruzstd",
- "zstd",
-]
-
-[[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "backtrace",
 ]
@@ -1927,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -1937,6 +1978,7 @@ dependencies = [
  "parity-util-mem",
  "paste",
  "rand 0.7.3",
+ "scale-info",
  "serde",
  "sp-application-crypto",
  "sp-arithmetic",
@@ -1948,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -1965,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -1977,9 +2019,10 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "parity-scale-codec",
+ "scale-info",
  "sp-runtime",
  "sp-std",
 ]
@@ -1987,7 +2030,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "hash-db",
  "log",
@@ -2010,12 +2053,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -2028,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "erased-serde",
  "log",
@@ -2046,11 +2089,12 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "hash-db",
  "memory-db",
  "parity-scale-codec",
+ "scale-info",
  "sp-core",
  "sp-std",
  "trie-db",
@@ -2060,11 +2104,12 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
+ "scale-info",
  "serde",
  "sp-runtime",
  "sp-std",
@@ -2075,10 +2120,9 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "parity-scale-codec",
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -2087,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#dbd21b967dfc98a44a43fdb96c468c21df51916e"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.11#32e82508f7ea5dc1ef77cf145644e2af6cc1846f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -2484,33 +2528,4 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zstd"
-version = "0.6.1+zstd.1.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de55e77f798f205d8561b8fe2ef57abfb6e0ff2abe7fd3c089e119cdb5631a3"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "3.0.1+zstd.1.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1387cabcd938127b30ce78c4bf00b30387dddf704e3f0881dbc4ff62b5566f8c"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "1.4.20+zstd.1.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd5b733d7cf2d9447e2c3e76a5589b4f5e5ae065c22a2bc0b023cbc331b6c8e"
-dependencies = [
- "cc",
- "libc",
 ]

--- a/pallet-chainlink-feed/Cargo.toml
+++ b/pallet-chainlink-feed/Cargo.toml
@@ -13,29 +13,31 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.125", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "2.0.1", features = ['derive'], default-features = false }
-sp-arithmetic = { git = 'https://github.com/paritytech/substrate.git', branch = 'master', default-features = false }
-sp-std = { git = 'https://github.com/paritytech/substrate.git', branch = 'master', default-features = false }
-sp-core = { git = 'https://github.com/paritytech/substrate.git', branch = 'master', default-features = false }
+codec = { package = "parity-scale-codec", version = "2.3.1", features = ['derive'], default-features = false }
+sp-arithmetic = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.11', default-features = false }
+sp-std = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.11', default-features = false }
+sp-core = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.11', default-features = false }
 # Needed for various traits. In our case, `OnFinalize`.
-sp-runtime = { git = 'https://github.com/paritytech/substrate.git', branch = 'master', default-features = false }
+sp-runtime = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.11', default-features = false }
 # Needed for type-safe access to storage DB.
-frame-support = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
+frame-support = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.11'}
 # `system` module provides us with all sorts of useful stuff and macros depend on it being around.
-frame-system = { git = 'https://github.com/paritytech/substrate.git', branch = 'master', default-features = false }
-frame-benchmarking = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'master', optional = true }
+frame-system = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.11', default-features = false }
+frame-benchmarking = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.11', optional = true }
 
 [dev-dependencies]
-sp-std = { git = 'https://github.com/paritytech/substrate.git', branch = 'master' }
-sp-io = { git = 'https://github.com/paritytech/substrate.git', branch = 'master' }
-pallet-balances = { git = 'https://github.com/paritytech/substrate.git', branch = 'master' }
+sp-std = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.11' }
+sp-io = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.11' }
+pallet-balances = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.11' }
 
 [features]
 default = ["std"]
 std = [
     "serde",
     "codec/std",
+    "scale-info/std",
     "sp-std/std",
     "sp-core/std",
     "sp-runtime/std",

--- a/pallet-chainlink-feed/src/benchmarking.rs
+++ b/pallet-chainlink-feed/src/benchmarking.rs
@@ -733,154 +733,154 @@ mod tests {
 	#[test]
 	fn create_feed() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_create_feed::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_create_feed());
 		});
 	}
 
 	#[test]
 	fn transfer_ownership() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_transfer_ownership::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_transfer_ownership());
 		});
 	}
 
 	#[test]
 	fn cancel_ownership_transfer() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_cancel_ownership_transfer::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_cancel_ownership_transfer());
 		});
 	}
 
 	#[test]
 	fn accept_ownership() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_accept_ownership::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_accept_ownership());
 		});
 	}
 
 	#[test]
 	fn submit_opening_round_answers() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_submit_opening_round_answers::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_submit_opening_round_answers());
 		});
 	}
 
 	#[test]
 	fn submit_closing_answer() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_submit_closing_answer::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_submit_closing_answer());
 		});
 	}
 
 	#[test]
 	fn change_oracles() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_change_oracles::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_change_oracles());
 		});
 	}
 
 	#[test]
 	fn update_future_rounds() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_update_future_rounds::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_update_future_rounds());
 		});
 	}
 
 	#[test]
 	fn set_requester() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_set_requester::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_set_requester());
 		});
 	}
 
 	#[test]
 	fn remove_requester() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_remove_requester::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_remove_requester());
 		});
 	}
 
 	#[test]
 	fn request_new_round() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_request_new_round::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_request_new_round());
 		});
 	}
 
 	#[test]
 	fn withdraw_payment() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_withdraw_payment::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_withdraw_payment());
 		});
 	}
 
 	#[test]
 	fn transfer_admin() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_transfer_admin::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_transfer_admin());
 		});
 	}
 
 	#[test]
 	fn cancel_admin_transfer() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_cancel_admin_transfer::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_cancel_admin_transfer());
 		});
 	}
 
 	#[test]
 	fn accept_admin() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_accept_admin::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_accept_admin());
 		});
 	}
 
 	#[test]
 	fn withdraw_funds() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_withdraw_funds::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_withdraw_funds());
 		});
 	}
 
 	#[test]
 	fn reduce_debt() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_reduce_debt::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_reduce_debt());
 		});
 	}
 
 	#[test]
 	fn transfer_pallet_admin() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_transfer_pallet_admin::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_transfer_pallet_admin());
 		});
 	}
 
 	#[test]
 	fn cancel_pallet_admin_transfer() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_cancel_pallet_admin_transfer::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_cancel_pallet_admin_transfer());
 		});
 	}
 
 	#[test]
 	fn accept_pallet_admin() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_accept_pallet_admin::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_accept_pallet_admin());
 		});
 	}
 
 	#[test]
 	fn set_feed_creator() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_set_feed_creator::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_set_feed_creator());
 		});
 	}
 
 	#[test]
 	fn remove_feed_creator() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_remove_feed_creator::<Test>());
+			assert_ok!(ChainlinkFeed::<Test>::test_benchmark_remove_feed_creator());
 		});
 	}
 }

--- a/pallet-chainlink-feed/src/lib.rs
+++ b/pallet-chainlink-feed/src/lib.rs
@@ -37,6 +37,7 @@ pub mod pallet {
 		convert::{TryFrom, TryInto},
 		prelude::*,
 	};
+	use scale_info::TypeInfo;
 
 	pub use crate::feed::{FeedBuilder, FeedBuilderOf};
 	use crate::{
@@ -50,7 +51,7 @@ pub mod pallet {
 	pub type RoundId = u32;
 
 	/// The configuration for an oracle feed.
-	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug)]
+	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 	pub struct FeedConfig<
 		AccountId: Parameter,
 		Balance: Parameter,
@@ -109,7 +110,7 @@ pub mod pallet {
 	/// Round data relevant to consumers.
 	/// Will only be constructed once minimum amount of submissions have
 	/// been provided.
-	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug)]
+	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 	pub struct Round<BlockNumber, Value> {
 		pub started_at: BlockNumber,
 		pub answer: Option<Value>,
@@ -134,7 +135,7 @@ pub mod pallet {
 	}
 
 	/// Round data relevant to oracles.
-	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug)]
+	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 	pub struct RoundDetails<Balance, BlockNumber, Value> {
 		pub submissions: Vec<Value>,
 		pub submission_count_bounds: (u32, u32),
@@ -146,7 +147,7 @@ pub mod pallet {
 		RoundDetails<BalanceOf<T>, <T as frame_system::Config>::BlockNumber, <T as Config>::Value>;
 
 	/// Meta data tracking withdrawable rewards and admin for an oracle.
-	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug)]
+	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 	pub struct OracleMeta<AccountId, Balance> {
 		pub withdrawable: Balance,
 		pub admin: AccountId,
@@ -156,7 +157,7 @@ pub mod pallet {
 	pub type OracleMetaOf<T> = OracleMeta<<T as frame_system::Config>::AccountId, BalanceOf<T>>;
 
 	/// Meta data tracking the oracle status for a feed.
-	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug)]
+	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 	pub struct OracleStatus<Value> {
 		pub starting_round: RoundId,
 		pub ending_round: Option<RoundId>,
@@ -184,14 +185,14 @@ pub mod pallet {
 	}
 
 	/// Used to store round requester permissions for accounts.
-	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug)]
+	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 	pub struct Requester {
 		pub delay: RoundId,
 		pub last_started_round: Option<RoundId>,
 	}
 
 	/// Round data as served by the `FeedInterface`.
-	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug)]
+	#[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 	pub struct RoundData<BlockNumber, Value> {
 		pub started_at: BlockNumber,
 		pub answer: Value,
@@ -428,14 +429,6 @@ pub mod pallet {
 	>;
 
 	#[pallet::event]
-	#[pallet::metadata(
-		T::AccountId = "AccountId",
-		T::FeedId = "FeedId",
-		T::BlockNumber = "BlockNumber",
-		T::Value = "Value",
-		RoundId = "RoundId",
-		SubmissionBounds = "SubmissionBounds"
-	)]
 	#[pallet::generate_deposit(pub (super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// A new oracle feed was created. \[feed_id, creator\]

--- a/pallet-chainlink-feed/src/mock.rs
+++ b/pallet-chainlink-feed/src/mock.rs
@@ -38,7 +38,7 @@ pub(crate) type AccountId = u64;
 pub(crate) type BlockNumber = u64;
 
 impl system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();


### PR DESCRIPTION
I have been testing this locally, so it felt dumb not to open a PR :). 

Note: This uses the latest metadata v14, so any polkadot.js will break and needs to be bumped to the latest version 